### PR TITLE
AIRFLOW-2193- Added r-base and rpy2 for ROperator 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
       libsasl2-dev \
       libsasl2-modules \
       locales \
+      r-base \
     && rm -rf /var/lib/apt/lists/*
+
+RUN echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
 
 RUN sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen \
     && locale-gen \
@@ -121,6 +124,7 @@ RUN sudo -H pip install --upgrade pip && \
     sudo -H pip install wheel tox && \
     sudo -H pip3 install --upgrade pip && \
     sudo -H pip3 install wheel tox && \
+    sudo -H pip3 install rpy2 && \
     rm -rf ~/.cache
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,6 @@ RUN sudo -H pip install --upgrade pip && \
     sudo -H pip install wheel tox && \
     sudo -H pip3 install --upgrade pip && \
     sudo -H pip3 install wheel tox && \
-    sudo -H pip3 install rpy2 && \
     rm -rf ~/.cache
 
 EXPOSE 8080


### PR DESCRIPTION
Added r-base and rpy2 for open ROperator pull request in: https://github.com/apache/airflow/pull/3115. 

Docker image is building successfully.